### PR TITLE
[WIP] Tab and TabbedPage components

### DIFF
--- a/controls/AppBar.qml
+++ b/controls/AppBar.qml
@@ -83,9 +83,13 @@ ToolBar {
      */
     property alias title: titleLabel.text
 
+    property alias tabs: tabBar.contentData
+
+    property alias currentTabIndex: tabBar.currentIndex
+
     property AppToolBar toolbar
 
-    height: Device.gridUnit
+    height: Device.gridUnit + (tabBar.visible ? tabBar.height : 0)
 
     IconButton {
         id: leftButton
@@ -154,5 +158,12 @@ ToolBar {
                 onClicked: modelData.triggered(actionButton)
             }
         }
+    }
+
+    TabBar {
+        id: tabBar
+        width: parent.width
+        y: actionsRow.height
+        visible: contentChildren.count > 0
     }
 }

--- a/controls/CMakeLists.txt
+++ b/controls/CMakeLists.txt
@@ -36,6 +36,8 @@ set(QML_FILES
     SmoothFadeLoader.qml
     Subheader.qml
     SubheadingLabel.qml
+    Tab.qml
+    TabbedPage.qml
     ThinDivider.qml
     TitleLabel.qml
     Units.qml

--- a/controls/Tab.qml
+++ b/controls/Tab.qml
@@ -1,0 +1,47 @@
+/*
+ * This file is part of Fluid.
+ *
+ * Copyright (C) 2016 Michael Spencer <sonrisesoftware@gmail.com>
+ *
+ * $BEGIN_LICENSE:MPL2$
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * $END_LICENSE$
+ */
+
+import QtQuick 2.4
+import Fluid.Core 1.0
+
+Item {
+    id: tab
+
+    /*!
+       The title of this tab.
+     */
+    property string title
+
+    /*!
+       The icon displayed for this tab. This can be a Material Design icon or an icon from
+       FontAwesome. See \l Icon from more details.
+     */
+	property string iconName
+
+	/*!
+       A URL pointing to an image to display as the icon of this tab. By default, this is
+       a special URL representing the icon named by \l iconName from the Material Design
+       icon collection. The icon will be colorized using the specificed \l color,
+       unless you put ".color." in the filename, for example, "app-icon.color.svg".
+
+       \sa iconName
+       \sa Icon
+     */
+    property string iconSource: Utils.getSourceForIconName(iconName)
+
+    /*!
+     * Controls whether a close button will be shown for this tab.
+     */
+    property bool canRemove: false
+}

--- a/controls/TabbedPage.qml
+++ b/controls/TabbedPage.qml
@@ -1,0 +1,52 @@
+/*
+ * This file is part of Fluid.
+ *
+ * Copyright (C) 2016 Michael Spencer <sonrisesoftware@gmail.com>
+ *
+ * $BEGIN_LICENSE:MPL2$
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * $END_LICENSE$
+ */
+
+import QtQuick 2.4
+import QtQuick.Controls 2.0
+import Fluid.Controls 1.0
+
+Page {
+    id: page
+
+    default property alias contents: swipeView.contentChildren
+
+    property alias count: swipeView.count
+
+    readonly property int currentIndex: appBar.currentTabIndex
+
+    /*!
+       The currently selected tab.
+     */
+    readonly property Tab selectedTab: count > 0
+            ? swipeView.contentChildren[currentIndex] : null
+
+    onCurrentIndexChanged: swipeView.currentIndex = currentIndex
+
+    appBar.tabs: Repeater {
+        model: swipeView.contentChildren
+        delegate: TabButton {
+            text: modelData.title
+
+            // TODO: Add icon and optional close button
+        }
+    }
+
+    SwipeView {
+        id: swipeView
+        anchors.fill: parent
+        currentIndex: appBar.currentTabIndex
+
+        onCurrentIndexChanged: appBar.currentTabIndex = currentIndex
+    }
+}

--- a/controls/qmldir
+++ b/controls/qmldir
@@ -32,6 +32,8 @@ SmoothFadeImage 1.0 SmoothFadeImage.qml
 SmoothFadeLoader 1.0 SmoothFadeLoader.qml
 Subheader 1.0 Subheader.qml
 SubheadingLabel 1.0 SubheadingLabel.qml
+Tab 1.0 Tab.qml
+TabbedPage 1.0 TabbedPage.qml
 ThinDivider 1.0 ThinDivider.qml
 TitleLabel 1.0 TitleLabel.qml
 singleton FluidStyle 1.0 FluidStyle.qml

--- a/demo/BasicComponents.qml
+++ b/demo/BasicComponents.qml
@@ -19,7 +19,7 @@ import QtQuick.Controls.Universal 2.0
 import Fluid.Controls 1.0
 import "Pages/Basic"
 
-Page {
+Tab {
     title: qsTr("Basic Components")
 
     Pane {

--- a/demo/CompoundComponents.qml
+++ b/demo/CompoundComponents.qml
@@ -19,7 +19,9 @@ import QtQuick.Controls.Universal 2.0
 import Fluid.Controls 1.0
 import "Pages/Compound"
 
-Item {
+Tab {
+    title: qsTr("Compound Components")
+
     Pane {
         id: listPane
         anchors {

--- a/demo/MaterialComponents.qml
+++ b/demo/MaterialComponents.qml
@@ -19,7 +19,9 @@ import QtQuick.Controls.Universal 2.0
 import Fluid.Controls 1.0
 import "Pages/Material"
 
-Item {
+Tab {
+    title: qsTr("Material Components")
+
     Pane {
         id: listPane
         anchors {

--- a/demo/NavigationComponents.qml
+++ b/demo/NavigationComponents.qml
@@ -19,7 +19,9 @@ import QtQuick.Controls.Universal 2.0
 import Fluid.Controls 1.0
 import "Pages/Navigation"
 
-Item {
+Tab {
+    title: qsTr("Nagitation Components")
+
     Pane {
         id: listPane
         anchors {

--- a/demo/Style.qml
+++ b/demo/Style.qml
@@ -19,7 +19,9 @@ import QtQuick.Controls.Universal 2.0
 import Fluid.Controls 1.0
 import "Pages/Style"
 
-Item {
+Tab {
+    title: qsTr("Style")
+
     Pane {
         id: listPane
         anchors {

--- a/demo/main.qml
+++ b/demo/main.qml
@@ -71,43 +71,13 @@ FluidWindow {
         ]
     }
 
-    initialPage: Page {
-        header: ToolBar {
-            TabBar {
-                id: bar
-                width: parent.width
+    initialPage: TabbedPage {
+        title: window.title
 
-                TabButton {
-                    text: qsTr("Basic components")
-                }
-
-                TabButton {
-                    text: qsTr("Compound components")
-                }
-
-                TabButton {
-                    text: qsTr("Material components")
-                }
-
-                TabButton {
-                    text: qsTr("Navigation components")
-                }
-
-                TabButton {
-                    text: qsTr("Style")
-                }
-            }
-        }
-
-        StackLayout {
-            anchors.fill: parent
-            currentIndex: bar.currentIndex
-
-            BasicComponents {}
-            CompoundComponents {}
-            MaterialComponents {}
-            NavigationComponents {}
-            Style {}
-        }
+        BasicComponents {}
+        CompoundComponents {}
+        MaterialComponents {}
+        NavigationComponents {}
+        Style {}
     }
 }


### PR DESCRIPTION
This implements an API similar to what was in QML Material, with a Tab component that holds the tab content as well as as the title, icon, and whether the tab is closable. I'll be using this in Terminal as I update it to use Fluid.
