### PR TITLE
Fix wave being visible in its initial state and add it to demo

### DIFF
--- a/src/demo/qml/MaterialComponents.qml
+++ b/src/demo/qml/MaterialComponents.qml
@@ -45,6 +45,7 @@ Tab {
             model: ListModel {
                 ListElement { title: qsTr("ActionButton"); source: "qrc:/qml/Pages/Material/ActionButtonPage.qml" }
                 ListElement { title: qsTr("BottomSheet"); source: "qrc:/qml/Pages/Material/BottomSheetPage.qml" }
+                ListElement { title: qsTr("Wave"); source: "qrc:/qml/Pages/Material/WavePage.qml" }
             }
             header: Subheader {
                 text: qsTr("Demos")

--- a/src/demo/qml/Pages/Material/WavePage.qml
+++ b/src/demo/qml/Pages/Material/WavePage.qml
@@ -22,9 +22,6 @@ import "../.."
 Item {
     Wave {
         id: wave
-        initialX: parent.width - size
-        initialY: parent.height - size
-        size: 48
         color: Material.accentColor
     }
 

--- a/src/imports/material/Wave.qml
+++ b/src/imports/material/Wave.qml
@@ -24,7 +24,7 @@ Rectangle {
     id: wave
 
     property bool opened
-    property real size
+    property real size: 0
     property real initialX
     property real initialY
     property real abstractWidth: parent.width


### PR DESCRIPTION
In the demo there is an unused page for the Wave animation, which had the problem that the wave animation was visible before being triggered (see at the bottom right):
![before](https://cloud.githubusercontent.com/assets/21310755/25196732/d001ba24-2541-11e7-95ac-1252c6574e5b.png)
I fixed this problem and added the page to the demo.