### PR TITLE
Feature/searchbar

### DIFF
--- a/src/demo/demo.qrc
+++ b/src/demo/demo.qrc
@@ -33,5 +33,6 @@
         <file>qml/Pages/Material/WavePage.qml</file>
         <file>qml/Pages/Navigation/NavDrawerPage.qml</file>
         <file>qml/Pages/Compound/OverlayPage.qml</file>
+        <file>qml/Pages/Material/Search.qml</file>
     </qresource>
 </RCC>

--- a/src/demo/qml/MaterialComponents.qml
+++ b/src/demo/qml/MaterialComponents.qml
@@ -46,6 +46,9 @@ Tab {
                 ListElement { title: qsTr("ActionButton"); source: "qrc:/qml/Pages/Material/ActionButtonPage.qml" }
                 ListElement { title: qsTr("BottomSheet"); source: "qrc:/qml/Pages/Material/BottomSheetPage.qml" }
                 ListElement { title: qsTr("Wave"); source: "qrc:/qml/Pages/Material/WavePage.qml" }
+                ListElement {
+                    title: qsTr("Search"); source: "qrc:/qml/Pages/Material/Search.qml"
+                }
             }
             header: Subheader {
                 text: qsTr("Demos")

--- a/src/demo/qml/Pages/Material/Search.qml
+++ b/src/demo/qml/Pages/Material/Search.qml
@@ -1,0 +1,79 @@
+/*
+ * This file is part of Fluid.
+ *
+ * Copyright (C) 2017 Magnus Groß <magnus.gross21@gmail.com>
+ *
+ * $BEGIN_LICENSE:MPL2$
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * $END_LICENSE$
+ */
+
+import QtQuick 2.0
+import QtQuick.Controls 2.0
+import QtQuick.Controls.Material 2.0
+import Fluid.Controls 1.0
+import Fluid.Material 1.0
+
+Item {
+    SearchBar {
+        id: searchbar
+        ListModel {
+            id: searchResults
+        }
+        onSearchTextChanged: {
+            if ("fluid".startsWith(searchText)) {
+                searchSuggestions.append({text: "fluid"});
+                searchSuggestions.append({text: "fluid demo"});
+                searchSuggestions.append({text: "fluid interface"});
+                searchSuggestions.append({text: "fluid layout"});
+            } else if ("liri".startsWith(searchText)) {
+                searchSuggestions.append({text: "liri"});
+                searchSuggestions.append({text: "liri os"});
+            }
+        }
+        onSearch: {
+            searchResults.append({title: "example search result", body: "This text can go over multiple lines and automatically wraps accordingly. This section is used to provide a short description of the search result.", uri: query+"0"})
+            searchResults.append({title: "second example search result", body: "Description", uri: query+"1"})
+            searchResults.append({title: "third example search result", body: "Description", uri: query+"2"})
+        }
+    }
+    ListView {
+        id: resultsListView
+        visible: searchResults.count != 0
+        anchors.top: searchbar.bottom
+        x: searchbar.x
+        width: parent.width
+        height: parent.height
+        model: searchResults
+        clip: true
+        delegate: Item {
+            width: parent.width
+            height: 128
+            Card {
+                anchors.fill: parent
+                anchors.margins: 8
+                Ripple {
+                    anchors.fill: parent
+                    onClicked: console.log(model.uri)
+                }
+                Column {
+                    anchors.fill: parent
+                    anchors.margins: 16
+                    spacing: 16
+                    TitleLabel {
+                        text: model.title
+                    }
+                    BodyLabel {
+                        width: parent.width
+                        text: model.body
+                        wrapMode: Text.WordWrap
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/demo/qml/Pages/Material/WavePage.qml
+++ b/src/demo/qml/Pages/Material/WavePage.qml
@@ -24,7 +24,6 @@ Item {
         id: wave
         color: Material.accentColor
     }
-
     Button {
         anchors.centerIn: parent
         text: qsTr("Toggle")

--- a/src/imports/material/SearchBar.qml
+++ b/src/imports/material/SearchBar.qml
@@ -110,7 +110,6 @@ Flickable {
         }
         Wave {
             id: searchWave
-            clip: true
             color: waveColor
             Card {
                 id: searchCard

--- a/src/imports/material/SearchBar.qml
+++ b/src/imports/material/SearchBar.qml
@@ -1,0 +1,207 @@
+/*
+ * This file is part of Fluid.
+ *
+ * Copyright (C) 2017 Magnus Groß <magnus.gross21@gmail.com>
+ *
+ * $BEGIN_LICENSE:MPL2$
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * $END_LICENSE$
+ */
+
+import QtQuick 2.8
+import QtQuick.Controls 2.1
+import QtQuick.Controls.Material 2.1
+import QtQuick.Layouts 1.1
+import Fluid.Controls 1.0
+import Fluid.Material 1.0
+
+/*!
+  \qmltype SearchBar
+  \inqmlmodule Fluid.Material
+  \brief Provides a searchbar, that supports autocompletion and displays search results using cards.
+*/
+
+Flickable {
+    id: searchBar
+
+    /*!
+      The current search text in the search bar typed in so far.
+    */
+    property alias searchText: searchTextField.text
+
+    /*!
+      The suggestions to display.
+      \sa textRole
+      \sa suggestionDelegate
+    */
+    property alias searchSuggestions: suggestionsListView.model
+
+    /*!
+      The delegate item for the suggestion list view.
+      \sa searchSuggestions
+    */
+    property alias suggestionDelegate: suggestionsListView.delegate
+
+    /*!
+      The model type that contains the text to display in the suggestion delegate
+      \sa searchSuggestions
+    */
+    property string suggestionTextRole: "text"
+
+    /*!
+      The string to display when the search field is empty
+    */
+    property string searchPlaceHolder: qsTr("Search")
+
+    /*!
+      The width of the search card. By default the search bar centers in the parent with a margin of 64 each side
+    */
+    property int cardWidth: searchBar.width - 128
+
+    /*!
+      The viewable area of the suggestions list until it begins scrolling.
+    */
+    property int suggestionsHeight: 300
+
+    /*!
+      The background color of the expanded search bar.
+    */
+    property color waveColor: Material.accentColor
+
+    /*!
+      Is emitted, when the user searches for a query. The \a query parameter contains the search query as string. Use this signal to provide search results.
+    */
+    signal search(string query)
+
+    /*!
+      Opens the search bar
+    */
+    function open() {
+        searchWave.open(openSearchButton.x, openSearchButton.y);
+        searchTextField.forceActiveFocus();
+    }
+
+    /*!
+      Closes the search bar
+    */
+    function close() {
+        searchWave.close(searchWave.initialX, searchWave.initialY);
+        searchSuggestions.clear();
+        searchResults.clear();
+    }
+
+    anchors {left: parent.left; right: parent.right; top: parent.top}
+    height: 64
+
+    Item {
+        anchors.fill: parent
+        clip: true
+        IconButton {
+            id: openSearchButton
+            iconName: "action/search"
+            anchors.right: parent.right
+            anchors.top: parent.top
+            anchors.margins: 8
+            onClicked: open()
+        }
+        Wave {
+            id: searchWave
+            clip: true
+            color: waveColor
+            Card {
+                id: searchCard
+                x: searchWave.size/2 - width
+                y: searchWave.size/2 + openSearchButton.height/2 - height/2
+                width: cardWidth
+                height: openSearchButton.height
+                IconButton {
+                    id: dismissSearchButton
+                    iconName: "navigation/arrow_back"
+                    anchors.left: parent.left
+                    anchors.verticalCenter: parent.verticalCenter
+                    rotation: searchWave.opened ? 0 : 180
+                    onClicked: close()
+                    Behavior on rotation {
+                        NumberAnimation {
+                            easing.type: Easing.InOutCubic
+                            duration: 150
+                        }
+                    }
+                }
+                TextInput {
+                    id: searchTextField
+                    anchors.verticalCenter: parent.verticalCenter
+                    anchors.left: dismissSearchButton.right
+                    anchors.right: resetSearchButton.left
+                    font.pixelSize: parent.height/2
+                    Keys.onReturnPressed: search(text)
+                    Keys.onEscapePressed: close()
+                    Keys.onDownPressed: suggestionsListView.forceActiveFocus()
+                    onTextChanged: {
+                        searchResults.clear();
+                        searchSuggestions.clear();
+                    }
+                }
+                Label {
+                    text: searchPlaceHolder
+                    visible: searchTextField.text === ""
+                    anchors.fill: searchTextField
+                    font.pixelSize: searchTextField.font.pixelSize
+                    color: Material.color(Material.Grey, Material.Shade400)
+                }
+
+                IconButton {
+                    id: resetSearchButton
+                    opacity: searchTextField.text !== ""
+                    anchors.top: parent.top
+                    anchors.bottom: parent.bottom
+                    anchors.right: parent.right
+                    iconName: "navigation/close"
+                    rotation: opacity*90
+                    onClicked: {
+                        searchTextField.clear();
+                        searchTextField.forceActiveFocus();
+                    }
+                    Behavior on opacity {
+                        NumberAnimation {
+                            easing.type: Easing.InOutCubic
+                            duration: 200
+                        }
+                    }
+                }
+            }
+        }
+    }
+    ListView {
+        id: suggestionsListView
+        visible: searchResults.count === 0
+        anchors.top: parent.bottom
+        x: searchCard.x
+        width: cardWidth
+        height: suggestionsHeight
+        model: ListModel {}
+        clip: true
+        Keys.onUpPressed: {
+            if (currentIndex == 0) {
+                searchTextField.forceActiveFocus();
+            } else {
+                decrementCurrentIndex();
+            }
+        }
+        delegate: ListItem {
+            text: model[suggestionTextRole]
+            highlighted: suggestionsListView.focus === true && suggestionsListView.currentIndex === index
+            function autoComplete() {
+                searchTextField.text = this.text;
+                searchTextField.forceActiveFocus();
+            }
+            Keys.onReturnPressed: autoComplete();
+            onClicked: autoComplete();
+            iconName: "action/search"
+        }
+    }
+}

--- a/src/imports/material/Wave.qml
+++ b/src/imports/material/Wave.qml
@@ -51,6 +51,7 @@ Rectangle {
     radius: size/2
     x: initialX - size/2
     y: initialY - size/2
+    clip: true
 
     states: State {
         name: "opened"

--- a/src/imports/material/material.qrc
+++ b/src/imports/material/material.qrc
@@ -8,6 +8,7 @@
         <file>plugins.qmltypes</file>
         <file>qmldir</file>
         <file>Ripple.qml</file>
+        <file>SearchBar.qml</file>
         <file>Wave.qml</file>
     </qresource>
 </RCC>

--- a/src/imports/material/qmldir
+++ b/src/imports/material/qmldir
@@ -7,4 +7,5 @@ BottomSheetList 1.0 BottomSheetList.qml
 BottomSheetGrid 1.0 BottomSheetGrid.qml
 ElevationEffect 1.0 ElevationEffect.qml
 Ripple 1.0 Ripple.qml
+SearchBar 1.0 SearchBar.qml
 Wave 1.0 Wave.qml


### PR DESCRIPTION
This pull request adds a [Material design Search bar](https://material.io/guidelines/patterns/search.html), which makes it very easy to implement a search feature in an app. The SearchBar exposes a simple interface to do so, for example to display search results, you only have to handle the  `signal search(string query)` and add search results to a model, which then are automatically displayed. The searchbar also supports autocompletions and exposes most properties. Since the search bar is an example of using the wave animation, I added it to the Wave demo page:
[Here is a short gif, showing how it looks now](https://gfycat.com/EllipticalDesertedDuckbillcat)
I also wrote documentation to further clarify the usage.

The search bar size tries to fill the parent by default with a little margin, but you can explicitly set the card size too.

Btw. could you maybe consider adding a CONTRIBUTING.md? I had to extract your coding style from other files. For example, you could shortly describe the order of property, signal and functions in QML files, and I also wasn't sure about the license header, so I just copied the license header from another file and added my email.

If there is any coding preference of yours, that I didn't follow, please just tell me the details and I will work out another commit fixing it. :)