### PR TITLE
Correct QMake instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ On the `qmake` line, you can specify additional configuration parameters:
 
  * `LIRI_INSTALL_PREFIX=/path/to/install` (for example `/opt/liri` or `/usr`)
  * `CONFIG+=debug` if you want a debug build
- * `CONFIG+=use_qt_paths` to install plugins and QML modules inside Qt
+ * `CONFIG+=install_under_qt` to install plugins and QML modules inside Qt
 
 Use `make distclean` from inside your `build` directory to clean up.
 You need to do this before rerunning `qmake` with different options.


### PR DESCRIPTION
`CONFIG+=install_under_qt` should be used to install Fluid
under Qt using QMake.