### PR TITLE
Pop a page from the stack at back button event

### DIFF
--- a/src/imports/controls/Page.qml
+++ b/src/imports/controls/Page.qml
@@ -125,6 +125,14 @@ Page {
         return StackView.view.push({item: component, properties: properties});
     }
 
+    Keys.onReleased: {
+        // catches the Android back button event and pops the page, if it isn't the top page
+        if (event.key === Qt.Key_Back && StackView.view.depth > 1) {
+            pop(event, false);
+            event.accepted = true;
+        }
+    }
+
     header: null
     footer: null
 


### PR DESCRIPTION
This pull request fixes #108.
When the back button event is ignored, Qt automatically causes the app to exit. With this patch it now only causes the last page to be popped.

It still doesn't catch the event, when the top level page is the current page (on purpose), because the developer might want to catch the event by himself/herself, e.g. to ask for unsaved changes before closing. So the default behavior for the top level page is to still close when the back button is pressed. If you feel like this is a bad decision, feel free to request another idea.