### PR TITLE
Feature/wave improvement

### DIFF
--- a/src/demo/qml/Pages/Material/WavePage.qml
+++ b/src/demo/qml/Pages/Material/WavePage.qml
@@ -32,10 +32,10 @@ Item {
         anchors.centerIn: parent
         text: qsTr("Toggle")
         onClicked: {
-            if (wave.opened)
-                wave.close(parent.width - wave.size, parent.height - wave.size)
+            if (wave.open)
+                wave.closeWave(parent.width - wave.size, parent.height - wave.size)
             else
-                wave.open(0, 0)
+                wave.openWave(0, 0)
         }
     }
 }

--- a/src/demo/qml/Pages/Material/WavePage.qml
+++ b/src/demo/qml/Pages/Material/WavePage.qml
@@ -22,7 +22,11 @@ import "../.."
 Item {
     Wave {
         id: wave
-        color: Material.accentColor
+        anchors.fill: parent
+        Rectangle {
+            anchors.fill: parent
+            color: Material.accentColor
+        }
     }
     Button {
         anchors.centerIn: parent

--- a/src/imports/material/SearchBar.qml
+++ b/src/imports/material/SearchBar.qml
@@ -82,7 +82,7 @@ Flickable {
       Opens the search bar
     */
     function open() {
-        searchWave.open(openSearchButton.x, openSearchButton.y);
+        searchWave.openWave(openSearchButton.x, openSearchButton.y);
         searchTextField.forceActiveFocus();
     }
 
@@ -90,7 +90,7 @@ Flickable {
       Closes the search bar
     */
     function close() {
-        searchWave.close(searchWave.initialX, searchWave.initialY);
+        searchWave.closeWave(searchWave.initialX, searchWave.initialY);
         searchSuggestions.clear();
         searchResults.clear();
     }
@@ -128,7 +128,7 @@ Flickable {
                     iconName: "navigation/arrow_back"
                     anchors.left: parent.left
                     anchors.verticalCenter: parent.verticalCenter
-                    rotation: searchWave.opened ? 0 : 180
+                    rotation: searchWave.open ? 0 : 180
                     onClicked: close()
                     Behavior on rotation {
                         NumberAnimation {

--- a/src/imports/material/SearchBar.qml
+++ b/src/imports/material/SearchBar.qml
@@ -100,7 +100,6 @@ Flickable {
 
     Item {
         anchors.fill: parent
-        clip: true
         IconButton {
             id: openSearchButton
             iconName: "action/search"
@@ -109,13 +108,19 @@ Flickable {
             anchors.margins: 8
             onClicked: open()
         }
+
         Wave {
             id: searchWave
-            color: waveColor
+            anchors.fill: parent
+            Rectangle {
+                anchors.fill: parent
+                color: waveColor
+            }
             Card {
                 id: searchCard
-                x: searchWave.size/2 - width
-                y: searchWave.size/2 + openSearchButton.height/2 - height/2
+                anchors.top: parent.top
+                anchors.left: parent.left
+                anchors.margins: Units.smallSpacing
                 width: cardWidth
                 height: openSearchButton.height
                 IconButton {

--- a/src/imports/material/Wave.qml
+++ b/src/imports/material/Wave.qml
@@ -112,6 +112,9 @@ Item {
         reversible: true
 
         SequentialAnimation {
+            ScriptAction {
+                script: wave.visible = wave.open;
+            }
             NumberAnimation {
                 property: "size"
                 easing.type: Easing.OutCubic

--- a/src/imports/material/Wave.qml
+++ b/src/imports/material/Wave.qml
@@ -28,9 +28,9 @@ Item {
     id: wave
 
     /*!
-      \c True, iif the wave is opened
+      Whether wave is open.
     */
-    property bool opened
+    property bool open
     /*!
       The current size of the wave
     */
@@ -52,33 +52,33 @@ Item {
     */
     property real abstractHeight: parent.height
     /*!
-      The diameter of the completely opened wave
+      The diameter of the completely open wave
     */
     property real diameter: 2 * Math.sqrt(Math.pow(Math.max(initialX, abstractWidth - initialX), 2)
             + Math.pow(Math.max(initialY, abstractHeight - initialY), 2))
 
     /*!
       This signal is emitted, when the wave has finished opening or closing.
-      \a opened defines, whether the wave was opened or closed
+      \a open defines, whether the wave was being opened or closed
     */
-    signal finished(bool opened)
+    signal finished(bool open)
 
     /*!
       Opens the wave centering the wave at (\a x, \a y)
     */
-    function open(x, y) {
+    function openWave(x, y) {
         wave.initialX = x || parent.width/2;
         wave.initialY = y || parent.height/2;
-        wave.opened = true;
+        wave.open = true;
     }
 
     /*!
       Closes the wave centering the wave at (\a x, \a y)
     */
-    function close(x, y) {
+    function closeWave(x, y) {
         wave.initialX = x || parent.width/2;
         wave.initialY = y || parent.height/2;
-        wave.opened = false;
+        wave.open = false;
     }
 
     layer.enabled: true
@@ -97,8 +97,8 @@ Item {
     }
 
     states: State {
-        name: "opened"
-        when: wave.opened
+        name: "open"
+        when: wave.open
 
         PropertyChanges {
             target: wave
@@ -108,7 +108,7 @@ Item {
 
     transitions: Transition {
         from: ""
-        to: "opened"
+        to: "open"
         reversible: true
 
         SequentialAnimation {
@@ -117,7 +117,7 @@ Item {
                 easing.type: Easing.OutCubic
             }
             ScriptAction {
-                script: wave.finished(wave.opened)
+                script: wave.finished(wave.open)
             }
         }
     }

--- a/src/imports/material/Wave.qml
+++ b/src/imports/material/Wave.qml
@@ -14,6 +14,7 @@
  */
 
 import QtQuick 2.4
+import QtGraphicalEffects 1.0
 
 /*!
    \qmltype Wave
@@ -22,7 +23,8 @@ import QtQuick 2.4
 
    \brief Provides a wave animation for transitioning between views of content.
  */
-Rectangle {
+
+Item {
     id: wave
 
     property bool opened
@@ -48,12 +50,20 @@ Rectangle {
         wave.opened = false;
     }
 
-    width: size
-    height: size
-    radius: size/2
-    x: initialX - size/2
-    y: initialY - size/2
-    clip: true
+    layer.enabled: true
+    layer.effect: OpacityMask {
+        maskSource: Item {
+            width: wave.width
+            height: wave.height
+            Rectangle {
+                x: initialX - size/2
+                y: initialY - size/2
+                width: size
+                height: size
+                radius: size/2
+            }
+        }
+    }
 
     states: State {
         name: "opened"

--- a/src/imports/material/Wave.qml
+++ b/src/imports/material/Wave.qml
@@ -27,23 +27,54 @@ import QtGraphicalEffects 1.0
 Item {
     id: wave
 
+    /*!
+      \c True, iif the wave is opened
+    */
     property bool opened
+    /*!
+      The current size of the wave
+    */
     property real size: 0
+    /*!
+      The horizontal center of the wave
+    */
     property real initialX
+    /*!
+      The vertical center of the wave
+    */
     property real initialY
+    /*!
+      The abstract width of the wave
+    */
     property real abstractWidth: parent.width
+    /*!
+      The abstract height of the wave
+    */
     property real abstractHeight: parent.height
+    /*!
+      The diameter of the completely opened wave
+    */
     property real diameter: 2 * Math.sqrt(Math.pow(Math.max(initialX, abstractWidth - initialX), 2)
             + Math.pow(Math.max(initialY, abstractHeight - initialY), 2))
 
+    /*!
+      This signal is emitted, when the wave has finished opening or closing.
+      \a opened defines, whether the wave was opened or closed
+    */
     signal finished(bool opened)
 
+    /*!
+      Opens the wave centering the wave at (\a x, \a y)
+    */
     function open(x, y) {
         wave.initialX = x || parent.width/2;
         wave.initialY = y || parent.height/2;
         wave.opened = true;
     }
 
+    /*!
+      Closes the wave centering the wave at (\a x, \a y)
+    */
     function close(x, y) {
         wave.initialX = x || parent.width/2;
         wave.initialY = y || parent.height/2;


### PR DESCRIPTION
# The Issue

The current wave implementation has a problem, it only is a wave for its background. It does not cut its children UI elements into a circular shape, but into a rectangular shape.
See for example the `SearchBar`:
![old](https://user-images.githubusercontent.com/21310755/29750493-bc22e81a-8b40-11e7-9be1-6df15190bb5d.png)
As you can see, only the background works. Every UI component is cut into a rectangular shape.

Another issue is that the underlying implementation caused the children objects to move depending on the size of the wave. This caused the user of a Wave having to manually move the position of children object depending on the wave's size in order to stay at the same position when the wave is animating. You can see this for example in the current `SearchBar` implementation.

This also caused a small performance problem, because it resulted in unnecessary bindings for the x and y property, which were then updated every frame during the animation: http://doc.qt.io/qt-5/qtquick-performance.html#visual-effects

# The fix

The fundamental implementation of Wave had to be changed, otherwise those two issues would not be fixable.
The fix implements the Wave using an `OpacityMask`, which is just a very small OpenGL shader, as you can see here: http://code.qt.io/cgit/qt/qtgraphicaleffects.git/tree/src/effects/OpacityMask.qml#n160

This allows the Wave to cut any children objects in circular shape, which means the first problem is fixed, as you can see here:
![new](https://user-images.githubusercontent.com/21310755/29750582-6001081c-8b42-11e7-9ca9-1743dceaf06e.png)

It simultaneously fixes the second issue, because now children objects are not moved at all in order for the Wave to work.
This means that the user of a Wave can much more comfortably use Waves, since anchors and absolute positions and stuff can be used without having to think about the size of the Wave.

And btw, since I already had the file open, I also documented Wave.qml. :)