### PR TITLE
Added fluid/qml to qml importpaths in examples/perproject/minimalqmake

### DIFF
--- a/examples/perproject/minimalqmake/src/main.cpp
+++ b/examples/perproject/minimalqmake/src/main.cpp
@@ -1,12 +1,20 @@
 #include <QGuiApplication>
 #include <QQmlApplicationEngine>
 
+
+#include "iconsimageprovider.h"
+#include "iconthemeimageprovider.h"
+
+
 int main(int argc, char *argv[])
 {
     QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
     QGuiApplication app(argc, argv);
 
     QQmlApplicationEngine engine;
+
+    engine.addImportPath("../fluid/qml");
+
     engine.load(QUrl(QLatin1String("qrc:/main.qml")));
 
     return app.exec();

--- a/examples/perproject/minimalqmake/src/src.pro
+++ b/examples/perproject/minimalqmake/src/src.pro
@@ -8,6 +8,9 @@ SOURCES += main.cpp
 
 RESOURCES += qml.qrc
 
+INCLUDEPATH +=  ../fluid/src/imports/controls
+INCLUDEPATH +=  ../fluid/src/imports/core
+
 # Additional import path used to resolve QML modules in Qt Creator's code model
 QML_IMPORT_PATH = $$OUT_PWD/../fluid/qml
 


### PR DESCRIPTION
	(1) Fixes the runtime error  module "Fluid.*" is not installed
	(2) adds include file for image providers
	(3) appends folder containing iconsimageprovider.h and iconthemeimageprovider.h
             to INCLUDEPATH