### PR TITLE
searchBar: Added new property and improved keyboard handling

### DIFF
--- a/src/imports/controls/SearchBar.qml
+++ b/src/imports/controls/SearchBar.qml
@@ -85,7 +85,7 @@ Item {
     /*!
       Whether the SearchBar is currently open
     */
-    property bool expanded: persistent ? true : false
+    readonly property alias expanded: searchWave.open
 
     /*!
       The model containing the search results
@@ -103,7 +103,6 @@ Item {
     function open() {
         searchWave.openWave(openSearchButton.x, openSearchButton.y);
         searchTextField.forceActiveFocus();
-        expanded = true;
     }
 
     /*!
@@ -117,7 +116,6 @@ Item {
         searchWave.closeWave(searchWave.initialX, searchWave.initialY);
         searchSuggestions.clear();
         searchResults.clear();
-        expanded = false;
         searchTextField.focus = false;
     }
 

--- a/src/imports/controls/SearchBar.qml
+++ b/src/imports/controls/SearchBar.qml
@@ -83,6 +83,11 @@ Item {
     property bool persistent: false
 
     /*!
+      Whether the SearchBar is currently open
+    */
+    property bool isopen: false
+
+    /*!
       The model containing the search results
     */
     property var searchResults: ListModel {}
@@ -98,6 +103,7 @@ Item {
     function open() {
         searchWave.openWave(openSearchButton.x, openSearchButton.y);
         searchTextField.forceActiveFocus();
+        isopen = true;
     }
 
     /*!
@@ -107,6 +113,8 @@ Item {
         searchWave.closeWave(searchWave.initialX, searchWave.initialY);
         searchSuggestions.clear();
         searchResults.clear();
+        isopen = false;
+        searchTextField.focus = false;
     }
 
     anchors {left: parent.left; right: parent.right; top: parent.top}
@@ -175,6 +183,7 @@ Item {
                         searchResults.clear();
                         searchSuggestions.clear();
                     }
+                    inputMethodHints: Qt.ImhNoPredictiveText
                 }
                 Label {
                     text: searchPlaceHolder

--- a/src/imports/controls/SearchBar.qml
+++ b/src/imports/controls/SearchBar.qml
@@ -85,7 +85,7 @@ Item {
     /*!
       Whether the SearchBar is currently open
     */
-    property bool isopen: false
+    property bool expanded: persistent ? true : false
 
     /*!
       The model containing the search results
@@ -103,17 +103,21 @@ Item {
     function open() {
         searchWave.openWave(openSearchButton.x, openSearchButton.y);
         searchTextField.forceActiveFocus();
-        isopen = true;
+        expanded = true;
     }
 
     /*!
       Closes the search bar
     */
     function close() {
+
+        if (persistent)
+            return;
+
         searchWave.closeWave(searchWave.initialX, searchWave.initialY);
         searchSuggestions.clear();
         searchResults.clear();
-        isopen = false;
+        expanded = false;
         searchTextField.focus = false;
     }
 


### PR DESCRIPTION
	(1) added a new property isopen which can be helpful to
      toggle searchBar visibility in certain applications.

	(2) the spell suggestions/predictive text feature  in the
      searchBar's TextInput prevents the trigger of onTextChanged
      unless the user accepts a spell suggestion for presses space
      bar. turning off the predictive text feature seems to
      improve the usability in mobiles.

	(3) The continued focus on the TextInput of SearchBar causes the
      onscreen keyboard to open up even if the SearchBar is closed.
      This problem is pronounced in mobiles. We have released the
      focus on the TextInput when the SearchBar is closed.