### PR TITLE
fix push() method of Page control

### DIFF
--- a/src/imports/controls/Page.qml
+++ b/src/imports/controls/Page.qml
@@ -137,7 +137,7 @@ Page {
         \sa StackView::push()
     */
     function push(component, properties) {
-        return StackView.view.push({item: component, properties: properties});
+        return StackView.view.push(component, properties);
     }
 
     Keys.onReleased: {


### PR DESCRIPTION
The PR fixes compatibility with the API of "Qt Quick Controls 2 > StackView".

Check the following links:
https://doc.qt.io/qt-5.10/qml-qtquick-controls2-stackview.html#push-method
vs
http://doc.qt.io/qt-5/qml-qtquick-controls-stackview.html#push-method

I suppose that the current implementation refers to the API of "Qt Quick Controls 1 > StackView" (instead of "Qt Quick Controls 2 > StackView"). So, it doesn't work.