### PR TITLE
New feature: allow to auto-highlight the current item of NavigationDrawer

### DIFF
--- a/src/imports/controls/NavigationDrawer.qml
+++ b/src/imports/controls/NavigationDrawer.qml
@@ -101,8 +101,29 @@ Drawer {
     */
     property alias topContent: topContent.data
 
+    /*!
+        \qmlproperty int currentIndex
+
+        The \c currentIndex property holds the index of the current item.
+    */
     property alias currentIndex: navDrawerListView.currentIndex
+
+    /*!
+        \qmlproperty Item currentItem
+
+        The \c currentItem property holds the current item.
+    */
     property alias currentItem: navDrawerListView.currentItem
+
+    /*!
+        \qmlproperty bool autoHighlight
+
+        This property holds whether auto-highlight is enabled.
+
+        If this property is \c true, the current item will be automatically highlighted.
+
+        The default value is \c false.
+    */
     property bool autoHighlight: false
 
     /*!

--- a/src/imports/controls/NavigationDrawer.qml
+++ b/src/imports/controls/NavigationDrawer.qml
@@ -101,6 +101,10 @@ Drawer {
     */
     property alias topContent: topContent.data
 
+    property alias currentIndex: navDrawerListView.currentIndex
+    property alias currentItem: navDrawerListView.currentItem
+    property bool autoHighlight: false
+
     /*!
         \qmlproperty list<QtObject> actions
 
@@ -161,13 +165,18 @@ Drawer {
                 model: drawer.actions
 
                 delegate: ListItem {
+                    property int modelIndex: index
+                    highlighted: drawer.autoHighlight ? ListView.isCurrentItem : false
                     icon.name: modelData.icon.name
                     icon.source: modelData.icon.source
                     text: modelData.text
                     showDivider: modelData.hasDividerAfter
                     dividerInset: 0
                     visible: modelData.visible
-                    onClicked: modelData.triggered(drawer)
+                    onClicked: {
+                        navDrawerListView.currentIndex = modelIndex
+                        modelData.triggered(drawer)
+                    }
                     enabled: modelData.enabled
                 }
 


### PR DESCRIPTION
The PR brings a new feature to highlight the current item of NavigationDrawer by setting the **autoHighlight** property value to true. Also, it comes with aliases for **navDrawerListView.currentIndex** and **navDrawerListView.currentItem** propepties.