### PR TITLE
exposed an alias to searchBar text input font property

### DIFF
--- a/src/imports/controls/SearchBar.qml
+++ b/src/imports/controls/SearchBar.qml
@@ -88,6 +88,11 @@ Item {
     readonly property alias expanded: searchWave.open
 
     /*!
+      The font of text in search TextInput box
+    */
+    property alias searchTextFont : searchTextField.font
+
+    /*!
       The model containing the search results
     */
     property var searchResults: ListModel {}


### PR DESCRIPTION
Currently the fontsize of the searchBar inputbox is large. It is
half the height of bar , this does not look appealing in phones
this property alias provides a way to override and customize
based on application needs.