### PR TITLE
added environment variable QT_VERSION to qdocEnvironment

### DIFF
--- a/doc/doc.qbs
+++ b/doc/doc.qbs
@@ -15,7 +15,8 @@ Product {
         "FLUID_VERSION=" + project.version,
         "FLUID_VERSION_TAG=" + versionTag,
         "SRCDIR=" + path,
-        "QT_INSTALL_DOCS=" + Qt.core.docPath
+        "QT_INSTALL_DOCS=" + Qt.core.docPath,
+        "QT_VERSION=" + Qt.core.version
     ]
 
     files: [


### PR DESCRIPTION
This addresses issue#211 , Qt version 5.10.1 expects QT_VERSION 
in  QTDIR/{arch}/doc/global/macros.qdocconf.