### PR TITLE
SearchBar: removal of forced keyboard focussing on open

### DIFF
--- a/src/imports/controls/SearchBar.qml
+++ b/src/imports/controls/SearchBar.qml
@@ -102,7 +102,6 @@ Item {
     */
     function open() {
         searchWave.openWave(openSearchButton.x, openSearchButton.y);
-        searchTextField.forceActiveFocus();
     }
 
     /*!


### PR DESCRIPTION

If a searchbar is opened explicitly by calling open() it grabs keyboard focus.
This may be too intrusive for certain applications and usage .  It may be a 
better idea to leave the focus control on user of the library.

For discussions pls refer:
https://github.com/lirios/fluid/issues/216