### PR TITLE
Expose AppBar overflow menu open state

### DIFF
--- a/doc/src/controls/AppBar.qdoc
+++ b/doc/src/controls/AppBar.qdoc
@@ -79,6 +79,15 @@
 */
 
 /*!
+    \qmlproperty bool AppBar::overflowMenuVisible
+
+    Value indicates if overflow menu is open or not.
+
+    \readonly
+    \since Fluid.Controls 1.1
+*/
+
+/*!
     \qmlproperty real AppBar::leftKeyline
 
     Keyline to align contents to the left to be visually appealing.

--- a/src/imports/controls/AppBar.qml
+++ b/src/imports/controls/AppBar.qml
@@ -35,8 +35,6 @@ QQC2.ToolBar {
 
     property int __iconSize: FluidCore.Device.gridUnit <= 48 ? 20 : 24
 
-    readonly property alias overflowMenuVisible: overflowMenu.visible
-
     property alias leftKeyline: titleLabel.x
 
     property int maxActionCount: toolbar ? toolbar.maxActionCount : 3

--- a/src/imports/controls/AppBar.qml
+++ b/src/imports/controls/AppBar.qml
@@ -35,6 +35,8 @@ QQC2.ToolBar {
 
     property int __iconSize: FluidCore.Device.gridUnit <= 48 ? 20 : 24
 
+    readonly property alias overflowMenuVisible: overflowMenu.visible
+
     property alias leftKeyline: titleLabel.x
 
     property int maxActionCount: toolbar ? toolbar.maxActionCount : 3

--- a/src/imports/controls/AppBar11.qml
+++ b/src/imports/controls/AppBar11.qml
@@ -38,6 +38,8 @@ QQC2.ToolBar {
 
     property color backgroundColor: appBar.Material.primaryColor
 
+    readonly property alias overflowMenuVisible: overflowMenu.visible
+
     property color decorationColor: Material.shade(backgroundColor, Material.Shade700)
 
     property alias leftKeyline: titleLabel.x


### PR DESCRIPTION
It is useful to know if overflow menu of AppBar is open or not. For example
NavigationDrawer dragMargin can be set to 0 when menu is open to disable
dragging drawer open at the same time as menu. Depending on application
there can be other situations where overflow menu state is valuable
information.

I did not see instructions how to run tests so I didn't run them.

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does the code keep building with this change?
- [ ] Do the unit tests pass with this change?
- [x] Is the commit message formatted according to CONTRIBUTING.MD?
- [ ] If this change fixes a bug (or a performance problem), is a regression
  test (or a benchmark) included?
- [x] Is a documentation update included (if this change modifies
  existing APIs, or introduces new ones)

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Affected core subsystem(s)

Please provide affected core subsystem(s).

### Description of change

Please provide a description of the change here.
Add a screenshot or a screencast if necessary.
