### PR TITLE
Support Qt static builds

### DIFF
--- a/examples/perproject/minimalqmake/src/main.cpp
+++ b/examples/perproject/minimalqmake/src/main.cpp
@@ -2,7 +2,7 @@
 #include <QGuiApplication>
 #include <QQmlApplicationEngine>
 
-#ifdef Q_OS_IOS
+#ifdef QT_STATIC
 #  include <QQmlExtensionPlugin>
 Q_IMPORT_PLUGIN(FluidCorePlugin)
 Q_IMPORT_PLUGIN(FluidControlsPlugin)

--- a/examples/perproject/minimalqmake/src/src.pro
+++ b/examples/perproject/minimalqmake/src/src.pro
@@ -45,7 +45,13 @@ ios {
     APP_QML_FILES.files = $$OUT_PWD/../fluid/qml/Fluid
     APP_QML_FILES.path = qml
     QMAKE_BUNDLE_DATA += APP_QML_FILES
+}
 
+win32 {
+    WINDEPLOYQT_OPTIONS = -qmldir $$OUT_PWD/../fluid/qml/Fluid
+}
+
+qtConfig(static) {
     QMAKE_LIBDIR += \
         $$OUT_PWD/../fluid/qml/Fluid/Core \
         $$OUT_PWD/../fluid/qml/Fluid/Controls \
@@ -57,10 +63,6 @@ ios {
         fluidcontrolsplugin \
         fluidcontrolsprivateplugin \
         fluidtemplatesplugin
-}
-
-win32 {
-    WINDEPLOYQT_OPTIONS = -qmldir $$OUT_PWD/../fluid/qml/Fluid
 }
 
 # Default rules for deployment.


### PR DESCRIPTION
iOS builds are all static, so we already had support for Qt static
builds. We just had to make it work for every target OS.

Closes: #219