### PR TITLE
Fix Snackbar disappearing immediately in some cases

### DIFF
--- a/src/imports/controls/SnackBar.qml
+++ b/src/imports/controls/SnackBar.qml
@@ -33,9 +33,8 @@ Item {
         snackButton.text = buttonText;
         snackButton.visible = buttonText !== "";
         popup.open();
-        if (timer.running) {
+        if (timer.running)
             timer.restart();
-        }
     }
 
     function close() {

--- a/src/imports/controls/SnackBar.qml
+++ b/src/imports/controls/SnackBar.qml
@@ -33,6 +33,9 @@ Item {
         snackButton.text = buttonText;
         snackButton.visible = buttonText !== "";
         popup.open();
+        if (timer.running) {
+            timer.restart();
+        }
     }
 
     function close() {


### PR DESCRIPTION
When a snackbar is opened again, while it is open, the timer is not
reset, which means that in the worst case the user will not see the new
message, because it leaves the screen just as it shows the new message.

This PR fixes this issue, by resetting the timer, when open() is called again on the snackbar.