### PR TITLE
Fix wrong usage of dynamic_cast

### DIFF
--- a/src/imports/controls-private/windowdecoration.cpp
+++ b/src/imports/controls-private/windowdecoration.cpp
@@ -105,7 +105,7 @@ bool WindowDecoration::eventFilter(QObject *object, QEvent *event)
         return QObject::eventFilter(object, event);
 
     if (event->type() == QEvent::PlatformSurface) {
-        auto pe = dynamic_cast<QPlatformSurfaceEvent *>(event);
+        auto pe = static_cast<QPlatformSurfaceEvent *>(event);
         if (pe->surfaceEventType() == QPlatformSurfaceEvent::SurfaceCreated) {
             updateDecorationColor();
             return true;


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does the code keep building with this change?
- [ ] Do the unit tests pass with this change?
- [ ] Is the commit message formatted according to CONTRIBUTING.MD?
- [ ] If this change fixes a bug (or a performance problem), is a regression
  test (or a benchmark) included?
- [ ] Is a documentation update included (if this change modifies
  existing APIs, or introduces new ones)

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Affected core subsystem(s)

Controls

### Description of change

This is a minor performance fix for WindowDecoration::eventFilter function.
`dynamic_cast` has been used there without checking for null pointer which makes it work like a slower version of `static_cast`.
[According to the Qt docs](https://doc.qt.io/qt-5/qevent.html#Type-enum) this cast is safe so instead of adding a null pointer check I've made the cast static.
