### PR TITLE
Make Snackbar resistent to height changes

### DIFF
--- a/src/imports/controls/SnackBar.qml
+++ b/src/imports/controls/SnackBar.qml
@@ -53,22 +53,25 @@ Item {
     Popup {
         id: popup
 
+        property int offset: 0
+
         Material.theme: Material.Dark
 
         modal: false
         closePolicy: Popup.NoAutoClose
 
         x: snackBar.fullWidth ? 0 : (snackBar.parent.width - width) / 2
+        y: snackBar.parent.height - offset
 
         width: snackBar.fullWidth ? snackBar.parent.width : snackLayout.implicitWidth
         height: snackLayout.implicitHeight
 
         enter: Transition {
-            NumberAnimation { property: "y"; from: snackBar.parent.height; to: snackBar.parent.height - popup.height }
+            NumberAnimation { property: "offset"; from: 0; to: popup.height }
         }
 
         exit: Transition {
-            NumberAnimation { property: "y"; from: snackBar.parent.height - popup.height; to: snackBar.parent.height }
+            NumberAnimation { property: "offset"; from: popup.height; to: 0 }
         }
 
         background: Rectangle {


### PR DESCRIPTION
See #278 

Fixes it by using an offset instead of the direct y value and thereby moving the evaluation of y to a later stage with a property binding that always uses the up-to-date values.