### PR TITLE
Fix Travis build

### DIFF
--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -12,6 +12,8 @@ dnf install -y \
     libappstream-glib \
     wayland-devel \
     qt5-qtwayland-devel
+# workaround for the missing renameat2 syscall
+strip --remove-section=.note.ABI-tag /usr/lib64/libQt5Core.so.5
 travis_end "install_packages"
 
 # Install artifacts


### PR DESCRIPTION
Qt 5.12 requires the renameat2 syscall, which is only available in
relatively new Linux kernels. The Travis system seems to be using a
rather old kernel that seems to be missing this syscall.

This patch uses a workaround to enable Travis CI again, until Travis
supports this syscall.

This patch should probably be reverted, once that Travis updates its available systems.

I have also tested, whether the non-default Xenial system on Travis supports this syscall, but also this configuration failed.