### PR TITLE
Explicitely depends on Wayland::Client on Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Qt >= 5.10.0 with at least the following modules is required:
 
 On Linux you also need:
 
+ * [wayland](https://gitlab.freedesktop.org/wayland/wayland) >= 1.15
  * [qtwayland](http://code.qt.io/cgit/qt/qtwayland.git)
 
 The following modules and their dependencies are required:

--- a/src/imports/controls-private/CMakeLists.txt
+++ b/src/imports/controls-private/CMakeLists.txt
@@ -5,12 +5,13 @@ if(LINUX AND NOT ANDROID)
     )
 
     find_package(QtWaylandScanner REQUIRED)
+    find_package(Wayland 1.15 COMPONENTS Client REQUIRED)
     find_package(Qt5WaylandClient REQUIRED)
     ecm_add_qtwayland_client_protocol(SOURCES
         PROTOCOL "${CMAKE_CURRENT_SOURCE_DIR}/extensions/liri-decoration.xml"
         BASENAME "liri-decoration")
     set(DEFINES FLUID_ENABLE_WAYLAND=1)
-    set(LIBRARIES Qt5::GuiPrivate Qt5::WaylandClient)
+    set(LIBRARIES Qt5::GuiPrivate Qt5::WaylandClient Wayland::Client)
 endif()
 
 liri_add_qml_plugin(fluidcontrolsprivate
@@ -34,5 +35,6 @@ liri_add_qml_plugin(fluidcontrolsprivate
         ${DEFINES}
     PUBLIC_LIBRARIES
         Qt5::QuickControls2
+    LIBRARIES
         ${LIBRARIES}
 )


### PR DESCRIPTION
On Linux we want to build a protocol client to change decoration
colors according to the Material Design specifications.

Turns out we need to explicitely depend on Wayland::Client because it
is not pulled in by Qt5::WaylandClient.

It used to works for Linux distributions that had wayland-client.h
under /usr/include (a path that is traditionally always included),
but doesn't work on OpenSuSE where it is installed under a different
path such as /usr/include/wayland.

Closes: #295