### PR TITLE
Qt 5.15 deprecation warning fixed: QLocale used instead

### DIFF
--- a/src/imports/core/dateutils.cpp
+++ b/src/imports/core/dateutils.cpp
@@ -13,6 +13,8 @@
  * $END_LICENSE$
  */
 
+#include <QtCore/QLocale>
+
 #include "dateutils.h"
 
 DateUtils::DateUtils(QObject *parent)
@@ -26,7 +28,7 @@ QString DateUtils::formattedDate(const QDate &date) const
         return tr("Today (%1)").arg(dayOfWeek(date));
     else if (date == QDate::currentDate().addDays(1))
         return tr("Tomorrow (%1)").arg(dayOfWeek(date));
-    return date.toString(Qt::DefaultLocaleShortDate);
+    return QLocale::system().toString(date, QLocale::ShortFormat);
 }
 
 QString DateUtils::formatDuration(qlonglong duration, DurationFormat format,
@@ -90,7 +92,7 @@ QString DateUtils::friendlyTime(const QDateTime &time, bool standalone) const
         return tr("1 day ago");
     else if (days <= 10)
         return tr("%1 days ago").arg(days);
-    QString string = time.toString(Qt::DefaultLocaleShortDate);
+    QString string = QLocale::system().toString(time, QLocale::ShortFormat);
     return standalone ? string : tr("on %1").arg(string);
 }
 


### PR DESCRIPTION
Just a small fix of annoying deprecation warning in Qt 5.15.   
This code should work correctly on older versions too.

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does the code keep building with this change?
- [ ] Do the unit tests pass with this change?
- [ ] Is the commit message formatted according to CONTRIBUTING.MD?
- [ ] If this change fixes a bug (or a performance problem), is a regression
  test (or a benchmark) included?
- [ ] Is a documentation update included (if this change modifies
  existing APIs, or introduces new ones)

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Affected core subsystem(s)

Please provide affected core subsystem(s).

### Description of change

Please provide a description of the change here.
Add a screenshot or a screencast if necessary.
