### PR TITLE
Adding searchBar integration for the page customConten

### DIFF
--- a/src/imports/controls/SearchBar11.qml
+++ b/src/imports/controls/SearchBar11.qml
@@ -45,6 +45,8 @@ Item {
 
     property var searchResults: ListModel {}
 
+    property var customContentIntegration: false
+
     signal search(string query)
 
     function open() {
@@ -62,7 +64,8 @@ Item {
         searchResults.clear();
         searchTextField.focus = false;
     }
-
+    
+    anchors.fill: customContentIntegration? parent: null
     anchors {left: parent.left; right: parent.right; top: parent.top}
     height: 64
 
@@ -72,7 +75,7 @@ Item {
             id: openSearchButton
 
             anchors.right: parent.right
-            anchors.top: parent.top
+            anchors.top: customContentIntegration? null: parent.top
             anchors.margins: 8
 
             icon.source: FluidControls.Utils.iconUrl("action/search")
@@ -91,6 +94,7 @@ Item {
             }
             FluidControls.Card {
                 id: searchCard
+                anchors.fill: customContentIntegration? parent: null                
                 anchors.top: parent.top
                 anchors.left: parent.left
                 anchors.margins: Units.smallSpacing


### PR DESCRIPTION
There is a problem when including the searchBar inside the menuBar (Page/customContents)
I added a new variable customContentIntegration (false by default), when used and changed to true the searchBar will fit inside the menu bar (customContent variable in fluidControls.Page)

The following screenshots shows the layouting problems without the changes of this PR:
![Untitled2](https://user-images.githubusercontent.com/15939806/103039466-453a4600-4571-11eb-89c0-7cfd4597ee1b.png)
![Untitled](https://user-images.githubusercontent.com/15939806/103039470-466b7300-4571-11eb-8b8e-0ee6d92a09fe.png)
