### PR TITLE
Small QML fixes

### DIFF
--- a/src/controls/qml/effects/Ripple.qml
+++ b/src/controls/qml/effects/Ripple.qml
@@ -71,7 +71,7 @@ MouseArea {
     property Item control
 
     clip: true
-    hoverEnabled: Device.hoverEnabled
+    hoverEnabled: Fluid.Device.hoverEnabled
 
     Connections {
         target: control

--- a/src/controls/qml/sheets/BottomSheetGrid.qml
+++ b/src/controls/qml/sheets/BottomSheetGrid.qml
@@ -16,7 +16,6 @@ import QtQuick
 import QtQuick.Controls as QQC2
 import QtQuick.Controls.impl as QQCImpl2
 import QtQuick.Controls.Material
-import QtQuick.Templates as T
 import Fluid as Fluid
 
 /*!


### PR DESCRIPTION
Fix a typo in Ripple.qml affecting the `hoverEnabled` property.

<s>Also use QtObject instead of Item as the type for the Units singleton since it is not a visible object. (No bug here, just a minor improvement.)</s> (this didn't work)
