### PR TITLE
Fix QML module setup, fixing image provider

### DIFF
--- a/src/controls/CMakeLists.txt
+++ b/src/controls/CMakeLists.txt
@@ -36,11 +36,36 @@ file(GLOB_RECURSE _qml CONFIGURE_DEPENDS
 )
 
 # ------------------------------------------------------------
-# Backing library
+# Define the QML module
 # ------------------------------------------------------------
-add_library(${LIBNAME} SHARED
-    ${_sources}
+set_source_files_properties(qml/core/Units.qml PROPERTIES
+    QT_QML_SINGLETON_TYPE TRUE
 )
+
+qt_add_qml_module(${LIBNAME}
+    SHARED
+    URI
+        Fluid
+    VERSION
+        2.0
+    SOURCES
+        ${_sources}
+    QML_FILES
+        ${_qml}
+    IMPORTS
+        QtQuick.Layouts
+    DEPENDENCIES
+        QtQuick
+        QtQuick.Templates
+        #Fluid.Private
+    PLUGIN_TARGET
+        ${LIBNAME}
+    CLASS_NAME
+        FluidPlugin
+    NO_PLUGIN_OPTIONAL
+    NO_GENERATE_PLUGIN_SOURCE
+)
+
 set_target_properties(${LIBNAME} PROPERTIES
     AUTOMOC ON
     AUTORCC ON
@@ -68,38 +93,6 @@ target_link_libraries(${LIBNAME}
 target_compile_definitions(${LIBNAME}
     PRIVATE
         FLUID_INSTALL_ICONS=$<IF:$<BOOL:${FLUID_INSTALL_ICONS}>,1,0>
-)
-
-# ------------------------------------------------------------
-# Define the QML module
-# ------------------------------------------------------------
-set_source_files_properties(qml/core/Units.qml PROPERTIES
-    QT_QML_SINGLETON_TYPE TRUE
-)
-
-qt_add_qml_module(${LIBNAME}
-    URI
-        Fluid
-    VERSION
-        2.0
-    SOURCES
-        ${_sources}
-    QML_FILES
-        ${_qml}
-    RESOURCES
-        ${_resources}
-    IMPORTS
-        QtQuick.Layouts
-    DEPENDENCIES
-        QtQuick
-        QtQuick.Templates
-        #Fluid.Private
-    #CLASS_NAME FluidPlugin
-    #NO_GENERATE_PLUGIN_SOURCE
-)
-
-set_source_files_properties(qml/Units.qml PROPERTIES
-    QT_QML_SINGLETON_TYPE TRUE
 )
 
 # Install library


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does the code keep building with this change?
- [x] Do the unit tests pass with this change?
- [x] Is the commit message formatted according to CONTRIBUTING.MD?
- [ ] If this change fixes a bug (or a performance problem), is a regression
  test (or a benchmark) included?

### Description of change

Use the setup recommended for the case of a QML module that needs a plugin class doing custom initialization for image providers at https://www.qt.io/blog/qml-modules-in-qt-6.2. This is a single library (instead of plugin + backing libraries) with the automatically generated plugin class disabled.

What's wrong with the current way? It results in two copies of the module registration, a manually defined one (Q_PLUGIN_METADATA) in the "backing" library and an automatically generated one in the "plugin" library. The linker may let the duplicate symbol definitions slide, but there is yet a consequence in that plugin initialization is not performed if the automatically generated registration code is selected when loading the module. This can be seen in the tests: although there is no test that directly checks whether the image provider is working, it prints several messages like
`QWARN  : tst_controls::IconTests::test_source_should_use_icon_prefix_for_material_icon() qrc:/qt/qml/Fluid/qml/Icon.qml:151:5: QML QQuickImage: Invalid image provider: image://fluidicontheme/action/settings`. This commit fixes those messages.

There is no simple way to add a .cpp file to the plugin library instead of the backing library, so that's why the best thing is to request a single instead of split library. Also the library has to be created by `qt_add_qml_module` instead of add_library, because `qt_add_qml_module` doesn't handle the case where the library already exists AND the backing + plugin libraries are combined.