### PR TITLE
Fix ripple effect on FloatingActionButton

### DIFF
--- a/src/controls/qml/buttons/FloatingActionButton.qml
+++ b/src/controls/qml/buttons/FloatingActionButton.qml
@@ -71,6 +71,7 @@ RoundButton {
     Material.elevation: 1
 
     background: Rectangle {
+        id: background
         implicitWidth: control.mini ? 40 : 56
         implicitHeight: implicitWidth
 
@@ -97,11 +98,11 @@ RoundButton {
             color: "black"
             cornerRadius: height/2
         }
+    }
 
-        Fluid.Ripple {
-            anchors.fill: parent
-            control: control
-            circular: true
-        }
+    Fluid.Ripple {
+        anchors.fill: background
+        control: control
+        circular: true
     }
 }


### PR DESCRIPTION


### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does the code keep building with this change?
- [x] Do the unit tests pass with this change?
- [x] Is the commit message formatted according to CONTRIBUTING.MD?
- [ ] If this change fixes a bug (or a performance problem), is a regression
  test (or a benchmark) included?


### Description of change

The Ripple's MouseArea wasn't receiving any mouse events. Moving it to this other spot fixed it. Seems like some kind of z-ordering issue although I don't see how it should make any difference according to the z ordering rules.
